### PR TITLE
OpenGraph meta tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,8 +1,14 @@
 <title>{% if page.title %} {{ page.title }} - {% endif %}Propel, The Blazing Fast Open-Source PHP 5.5 ORM</title>
 <meta name="language" content="en" >
 <meta http-equiv="content-type" content="text/html; charset=utf-8" >
-<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" >
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" > 
 <meta content='width=device-width' name='viewport'>
+
+
+<!-- OpenGraph meta tags -->
+<meta property="og:title" content="Propel, The Blazing Fast Open-Source PHP 5.5 ORM" />
+{% if page.title %} <meta property="og:description" content="{{ page.title }}" /> {% endif %}
+<meta property="og:image" content="http://propelorm.org/images/propel-logo.png" />
 
 <!-- Stylesheets -->
 <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Added the [OpenGraph](https://opengraphprotocol.org) meta tags for basic sharing preview.

I just put the HTML.
__TODO__ : consider using jekyll plugins for SEO ([Jekyll-SEO-Tags](https://jekyll.github.io/jekyll-seo-tag/) / [Jekyll-SEO](https://github.com/pmarsceill/jekyll-seo-gem))